### PR TITLE
Update per tutorial

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ how to :ref:`installation` the project.
 
 .. note::
 
-   This project is under active development.
+   This project is under active development. Lumache has its documentation hosted on Read the Docs.
 
 Contents
 --------


### PR DESCRIPTION
Added line: Lumache has its documentation hosted on Read the Docs.